### PR TITLE
removed the preview uploads done by staff in studio from the list of sub...

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -242,6 +242,8 @@ class StaffGradedAssignmentXBlock(XBlock):
                 if not submission:
                     continue
                 user = user_by_anonymous_id(student.student_id)
+                if not user:
+                    continue
                 module, _ = StudentModule.objects.get_or_create(
                     course_id=self.course_id,
                     module_state_key=self.location,


### PR DESCRIPTION
...missions

After adding the SGA block, and uploading the file form the studio itself make an entry in the submissions tables with a student_id of "student". As a result 
user = user_by_anonymous_id(student.student_id) {https://github.com/mitodl/edx-sga/blob/master/edx_sga/sga.py#L244}
returns None 
which breaks the UI when we see the list of submission on LMS side. It throws the following error

Traceback (most recent call last):
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 109, in get_response
response = callback(request, callback_args, *callback_kwargs)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 810, in handle_xblock_callback
return invoke_xblock_handler(request, course_id, usage_id, handler, suffix, request.user)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 895, in invoke_xblock_handler
resp = instance.handle(handler, req, suffix)
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/mixins.py", line 74, in handle
return self.runtime.handle(self, handler_name, request, suffix)
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1159, in handle
return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/runtime.py", line 1025, in handle
results = handler(request, suffix)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 424, in get_staff_grading_data
return Response(json_body=self.staff_grading_data())
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 283, in staff_grading_data
'assignments': list(get_student_data()),
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 253, in get_student_data
'module_type': self.category,
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 134, in get_or_create
return self.get_query_set().get_or_create(kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 450, in get_or_create
obj = self.model(params)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 355, in __init
setattr(self, field.name, rel_obj)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 362, in set
(instance._meta.object_name, self.field.name))
ValueError: Cannot assign None: "StudentModule.student" does not allow null values.

In order to resolve this I have made the fix and sent out the PR.
![screen shot 2015-03-05 at 3 54 19 pm](https://cloud.githubusercontent.com/assets/4256710/6503233/06c2141e-c351-11e4-8ca1-4248eccd08c5.png)
